### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ University but other portions may have potential for general use. It is
 relatively modular so you can use what you want. It is primarily structured as
 a Python distribution but the Octave files are also accessible independently.
 
-.. image:: https://pypip.in/version/gaitanalysistoolkit/badge.svg
+.. image:: https://img.shields.io/pypi/v/gaitanalysistoolkit.svg
     :target: https://pypi.python.org/pypi/gaitanalysistoolkit/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20gaitanalysistoolkit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `gaitanalysistoolkit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.