### PR TITLE
Changes to support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - DEP_VERSIONS="latest"
 before_install:
   - if [[ $DEP_VERSIONS == "oldest" ]]; then
-      sudo apt-get install -y -qq python-pip python-setuptools python-numpy python-scipy python-matplotlib python-tables python-nose python-coverage python-pandas python-sphinx python-mock python-numpydoc python-yaml;
+      sudo apt-get install -y -qq python-tk python-pip python-setuptools python-numpy python-scipy python-matplotlib python-tables python-nose python-coverage python-pandas python-sphinx python-mock python-numpydoc python-yaml;
       sudo pip install --no-deps oct2py==2.4.2 DynamicistToolKit==0.4.0;
     elif [[ $DEP_VERSIONS == "latest" ]]; then
       MINICONDA_URL="https://repo.continuum.io/miniconda";

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2014-2015 Cleveland State University
+Copyright 2014-2021 Cleveland State University
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ Installation
 
 You will need Python 2.7 or 3.7+ and setuptools to install the packages. Its
 best to install the dependencies first (NumPy, SciPy, matplotlib, Pandas,
-PyTables).  The SciPy Stack instructions are helpful for this:
-http://www.scipy.org/stackspec.html.
+PyTables).
 
 Supported versions:
 
@@ -75,7 +74,7 @@ Supported versions:
 - scipy >= 0.13.3
 - matplotlib >= 1.3.1
 - tables >= 3.1.1
-- pandas >= 0.13.1
+- pandas >= 0.13.1, <= 0.24.0
 - pyyaml >= 3.10
 - DynamicistToolKit >= 0.4.0
 - oct2py >= 2.4.2

--- a/README.rst
+++ b/README.rst
@@ -63,14 +63,14 @@ Several Octave routines are included in the ``gaitanalysis/octave`` directory.
 Installation
 ============
 
-You will need Python 2.7 and setuptools to install the packages. Its best to
-install the dependencies first (NumPy, SciPy, matplotlib, Pandas, PyTables).
-The SciPy Stack instructions are helpful for this:
+You will need Python 2.7 or 3.7+ and setuptools to install the packages. Its
+best to install the dependencies first (NumPy, SciPy, matplotlib, Pandas,
+PyTables).  The SciPy Stack instructions are helpful for this:
 http://www.scipy.org/stackspec.html.
 
 Supported versions:
 
-- python >= 2.7
+- python >= 2.7 or >= 3.7
 - numpy >= 1.8.2
 - scipy >= 0.13.3
 - matplotlib >= 1.3.1
@@ -201,6 +201,7 @@ Release Notes
 0.2.0
 -----
 
+- Support Python 3. [PR `#149`_]
 - Minimum dependencies bumped to Ubuntu 14.04 LTS versions and tests run on
   latest conda forge packages as of 2018/08/30. [PR `#140`_]
 - The minimum version of the required dependency, DynamicistToolKit, was bumped
@@ -211,6 +212,7 @@ Release Notes
 - Added note and setup.py check about higher oct2py versions required for
   Windows.
 
+.. _#149: https://github.com/csu-hmc/GaitAnalysisToolKit/pull/149
 .. _#134: https://github.com/csu-hmc/GaitAnalysisToolKit/pull/134
 .. _#135: https://github.com/csu-hmc/GaitAnalysisToolKit/pull/135
 .. _#140: https://github.com/csu-hmc/GaitAnalysisToolKit/pull/140

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'GaitAnalysisToolKit'
-copyright = u'2013, Jason K. Moore'
+copyright = u'2013-2021, Jason K. Moore'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/env-dev-latest.yml
+++ b/env-dev-latest.yml
@@ -2,17 +2,18 @@ name: gaitanalysis-dev-latest
 channels:
   - conda-forge
 dependencies:
-  - python =2.7.*
-  - numpy
-  - scipy
-  - matplotlib
-  - pytables
-  - pandas
-  - pyyaml
-  - dynamicisttoolkit
-  - oct2py
-  - nose
-  - sphinx
   - coverage
+  - dynamicisttoolkit
+  - ipython
+  - matplotlib
   - mock
+  - nose
+  - numpy
   - numpydoc
+  - oct2py
+  - pandas <0.24
+  - pytables
+  - python
+  - pyyaml
+  - scipy
+  - sphinx

--- a/gaitanalysis/controlid.py
+++ b/gaitanalysis/controlid.py
@@ -79,7 +79,7 @@ class SimpleControlSolver(object):
         self.controls = controls
 
         if validation_data is None:
-            num_gait_cycles = data.shape[0] / 2
+            num_gait_cycles = data.shape[0] // 2
             self.identification_data = data.iloc[:num_gait_cycles]
             self.validation_data = data.iloc[num_gait_cycles:]
         else:

--- a/gaitanalysis/motek.py
+++ b/gaitanalysis/motek.py
@@ -406,7 +406,7 @@ class DFlowData(object):
         optional meta data file."""
 
         with open(self.meta_yml_path, 'r') as f:
-            meta = yaml.load(f, Loader=yaml.FullLoader)
+            meta = yaml.load(f)
 
         return meta
 

--- a/gaitanalysis/motek.py
+++ b/gaitanalysis/motek.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # standard library
+from __future__ import division
 import re
 import os
 from distutils.version import LooseVersion
@@ -190,7 +191,7 @@ class MissingMarkerIdentifier(object):
         try:
             self.columns
         except AttributeError:
-            raise StandardError("You must run the `identify()` method " +
+            raise AttributeError("You must run the `identify()` method " +
                                 "before computing the statistics.")
 
         df = self.data_frame[self.columns]
@@ -324,9 +325,10 @@ class DFlowData(object):
                       'rfoot', 'rtoes']
 
     rotation_suffixes = ['.Rot' + c for c in ['X', 'Y', 'Z']]
-    segment_labels = [_segment + _suffix for _segment in dflow_segments for
-                      _suffix in marker_coordinate_suffixes +
-                      rotation_suffixes]
+    segment_labels = []
+    for _segment in dflow_segments:
+        for _suffix in marker_coordinate_suffixes + rotation_suffixes:
+            segment_labels.append(_segment + _suffix)
 
     # TODO: These should be stored in the meta data for each trial because
     # the names could theorectically change, as they are selected by the
@@ -404,7 +406,7 @@ class DFlowData(object):
         optional meta data file."""
 
         with open(self.meta_yml_path, 'r') as f:
-            meta = yaml.load(f)
+            meta = yaml.load(f, Loader=yaml.FullLoader)
 
         return meta
 
@@ -771,7 +773,8 @@ class DFlowData(object):
             '.Anlg': 'Sensor' + str(i+1).zfill(2) + '_' +
             signal for i in range(num_sensors) for j,signal in enumerate(signals)}
 
-        channel_names = dict(force_channels.items() + sensor_channels.items())
+        channel_names = dict(tuple(force_channels.items()) +
+                             tuple(sensor_channels.items()))
 
         # update labels from meta file
         try:
@@ -1220,7 +1223,7 @@ class DFlowData(object):
 
             return x_inertial, y_inertial, z_inertial
 
-        for sensor, rot_matrix in self.meta['trial']['sensor-orientation'].iteritems():
+        for sensor, rot_matrix in self.meta['trial']['sensor-orientation'].items():
             ax, ay, az = orient_accelerometer(np.array(rot_matrix),
                                               data_frame[sensor + '_AccX'],
                                               data_frame[sensor + '_AccY'],

--- a/gaitanalysis/tests/test_controlid.py
+++ b/gaitanalysis/tests/test_controlid.py
@@ -32,7 +32,7 @@ class TestSimpleControlSolver():
         self.p = len(self.sensors)
         self.q = len(self.controls)
         self.r = 10
-        self.m = self.r / 2
+        self.m = self.r // 2
 
         self.gain_inclusion_matrix = np.array(self.q * [self.p * [True]])
         self.gain_inclusion_matrix[0, 1] = False

--- a/gaitanalysis/tests/test_gait.py
+++ b/gaitanalysis/tests/test_gait.py
@@ -177,8 +177,8 @@ class TestGaitData():
         # Test for force plate version
         gait_data = GaitData(self.data_frame)
 
-        min_idx = len(self.data_frame) / 3
-        max_idx = 2*len(self.data_frame) / 3
+        min_idx = len(self.data_frame) // 3
+        max_idx = 2*len(self.data_frame) // 3
 
         min_time = self.data_frame.index.values.astype(float)[min_idx]
         max_time = self.data_frame.index.values.astype(float)[max_idx]

--- a/gaitanalysis/tests/test_motek.py
+++ b/gaitanalysis/tests/test_motek.py
@@ -3,7 +3,6 @@
 
 # builtin
 import os
-from time import strptime
 from distutils.version import LooseVersion
 from random import sample, choice
 
@@ -123,7 +122,7 @@ class TestMissingMarkerIdentfier:
 
         identifier = \
             MissingMarkerIdentifier(self.with_constant[marker_columns])
-        assert_raises(StandardError, identifier.statistics)
+        assert_raises(AttributeError, identifier.statistics)
 
 
 class TestSplineInterpolateOverMissing:
@@ -322,7 +321,7 @@ class TestDFlowData():
                                    'Sitting', 'Standing', 'Relaxing']
 
     meta_data = {'trial': {'id': 5,
-                           'datetime': strptime('2013-10-03', "%Y-%m-%d"),
+                           'datetime': '2013-10-03',
                            'notes': 'All about this trial.',
                            'nominal-speed': 5.0,
                            'nominal-speed-units': 'meters per second',
@@ -581,7 +580,8 @@ class TestDFlowData():
 
         time = self.record_data_frame['Time']
 
-        self.n_event_times = sorted(sample(time, self.number_of_events))
+        self.n_event_times = sorted(sample(time.values.tolist(),
+                                           self.number_of_events))
         event_letters = self.possible_event_names[:self.number_of_events]
         self.event_times = dict(zip(event_letters, self.n_event_times))
 
@@ -760,9 +760,9 @@ class TestDFlowData():
         hbm_lab, hbm_i, non_hbm_i = dflow_data._hbm_column_labels(all_labels)
 
         assert self.dflow_hbm_labels == hbm_lab
-        assert hbm_i == range(len(self.mocap_labels_without_hbm),
-                              len(self.mocap_labels_with_hbm))
-        assert non_hbm_i == range(len(self.mocap_labels_without_hbm))
+        assert hbm_i == list(range(len(self.mocap_labels_without_hbm),
+                              len(self.mocap_labels_with_hbm)))
+        assert non_hbm_i == list(range(len(self.mocap_labels_without_hbm)))
 
     def test_analog_channel_labels(self):
         dflow_data = DFlowData(self.path_to_mocap_data_file)

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(name='GaitAnalysisToolKit',
                    'Intended Audience :: Science/Research',
                    'Operating System :: OS Independent',
                    'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3.7',
                    'Topic :: Scientific/Engineering :: Physics',
                   ],
       )

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 from os.path import join
 
 from setuptools import setup, find_packages
 
 exec(open('gaitanalysis/version.py').read())
 
-description = \
-    """Various tools for gait analysis used at the Cleveland State
-University Human Motion and Control Lab."""
+description = ("Various tools for gait analysis used at the Cleveland State "
+               "University Human Motion and Control Lab.")
 
 octave_sub_dirs = ['2d_inverse_dynamics',
                    join('2d_inverse_dynamics', 'test'),
@@ -31,7 +29,7 @@ install_requires = ['numpy>=1.8.2',
                     'scipy>=0.13.3',
                     'matplotlib>=1.3.1',
                     'tables>=3.1.1',
-                    'pandas>=0.13.1',
+                    'pandas>=0.13.1,<0.24',
                     'pyyaml>=3.10',
                     'DynamicistToolKit>=0.4.0',
                     'oct2py>=2.4.2']
@@ -53,8 +51,8 @@ setup(name='GaitAnalysisToolKit',
       # The following ensures that any of these files are installed to the
       # system location.
       package_data={'gaitanalysis': octave_rel_paths,
-                    'gaitanalysis.tests': [join('data', glob)
-                              for glob in ['*.txt', '*.csv', '*.yml']]},
+                    'gaitanalysis.tests': [join('data', glob) for glob in
+                                           ['*.txt', '*.csv', '*.yml']]},
       tests_require=['nose>1.3.1'],
       test_suite='nose.collector',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
Fixes #141

- deals with integer division issues
- setup pandas to be < 0.24.0 which supports Python 2 and 3 (as well as
has get_store and Panel)
- uses items() instead of iteritems() on dictionaries
- deals with range() differences
- fixes issue with random.sample() being more strict
- don't use strptime() as it generates incorrect yaml now
- don't use StandardError
- deal with issue defining a class attribute and a variable not being
accessible in a list comprehension

Packages I did local testing with:
```
coverage                  5.5              py37h5e8e339_0    conda-forge
dynamicisttoolkit         0.5.3              pyh9f0ad1d_3    conda-forge
ipython                   7.24.1           py37h085eea5_0    conda-forge
matplotlib                3.4.2            py37h89c1867_0    conda-forge
matplotlib-base           3.4.2            py37hdd32ed1_0    conda-forge
mock                      4.0.3            py37h89c1867_1    conda-forge
nose                      1.3.7                   py_1006    conda-forge
numpy                     1.20.3           py37h038b26d_1    conda-forge
numpydoc                  1.1.0                      py_1    conda-forge
oct2py                    5.2.0              pyh9f0ad1d_0    conda-forge
pandas                    0.23.4          py37h637b7d7_1000    conda-forge
pytables                  3.6.1            py37h0c4f3e0_3    conda-forge
python                    3.7.10          hffdb5ce_100_cpython    conda-forge
pyyaml                    5.4.1            py37h5e8e339_0    conda-forge
scipy                     1.6.3            py37h29e03ee_0    conda-forge
sphinx                    4.0.2              pyh6c4a22f_1    conda-forge
octave              5.2.0
```